### PR TITLE
Fix link to UR types registry

### DIFF
--- a/Docs/ur-1-overview.md
+++ b/Docs/ur-1-overview.md
@@ -9,7 +9,7 @@ To be precise, Uniform Resources (URs) include:
 3. A standard way split and sequence longer messages.
 4. Optimizations for efficiency when URs are presented as QR codes.
 
-URs are a crucial element of the [Gordian architecture](https://github.com/BlockchainCommons/Gordian), allowing for the self-identified encoding of a variety of cryptographic data, [all listed in a registry of data types](06-urtypes.md), most notably including seeds, keys, shards, and PSBTs. It's focused on airgapped usage and allows for standardized interoperability for Bitcoin apps released by different companies.
+URs are a crucial element of the [Gordian architecture](https://github.com/BlockchainCommons/Gordian), allowing for the self-identified encoding of a variety of cryptographic data, [all listed in a registry of data types](https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-006-urtypes.md), most notably including seeds, keys, shards, and PSBTs. It's focused on airgapped usage and allows for standardized interoperability for Bitcoin apps released by different companies.
 
 > :bulb: _URs are used widely in our Gordian reference apps, but our community members have focused most on UR's sequencing feature to create animated QRs that support PSBTs. URs can do a lot more: they can support any airgapped Bitcoin function and more than that, can support data encoding for a large number of decentralized technologies._
 


### PR DESCRIPTION
This may or may not be the correct canonical link to the UR types registry. I didn't see the file when I looked in this repository.